### PR TITLE
Fix default status issue for new applications

### DIFF
--- a/app/controllers/applications_controller.rb
+++ b/app/controllers/applications_controller.rb
@@ -2,10 +2,6 @@ class ApplicationsController < ApplicationController
   def show
     @application = Application.find(params[:app_id])
     @pets = @application.pets
-
-    # if params[:app_status] == "In Progress"
-    #   @application.status = "In Progress"
-    # end
   end
 
   def new
@@ -19,6 +15,6 @@ class ApplicationsController < ApplicationController
 
   private
     def application_params
-      params.permit(:name, :street_address, :city, :state, :zip_code, :description, :status)
+      params.permit(:name, :street_address, :city, :state, :zip_code, :description, :status).with_defaults(status: "In Progress")
     end
 end

--- a/app/views/applications/new.html.erb
+++ b/app/views/applications/new.html.erb
@@ -18,5 +18,5 @@
   <%= form.label :description, "Description of why I would make a good home" %>
   <%= form.text_area :description  %>
   
-  <%= form.submit "Submit" %>
+  <%= form.submit "Submit"%>
 <% end %>

--- a/spec/features/applications/new_spec.rb
+++ b/spec/features/applications/new_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe "/applications/new" do
     fill_in "Description", with: "I believe there can never be too many cats"
 
     # save_and_open_page
-    click_button "Submit"
+    click_on "Submit"
 
     expect(current_path).to eq("/applications/#{Application.last.id}")
     expect(page).to have_content("Paul McCartney")


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [X] The commit message follows our guidelines
- [X] The branch created follows our guidelines
- [X] Tests for the changes have been added (for bug fixes/features)



* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

This PR has a bug fix to address the issue where our Applications `:status` was defaulting to `nil` and we wanted to update it to "In Progress" upon creating of an Application object. Now our Applications will be starting with a default value of "In Progress" 

* **What is the new behavior (if this is a feature change)?**

Implemented a method / behavior on the `def create` by chaining `.with_defaults(status: "In Progress")` onto the params. Thus setting a default status.

* **Other information**: