### PR TITLE
Add features and testing specs for rejecting a pet on an app

### DIFF
--- a/app/models/pet.rb
+++ b/app/models/pet.rb
@@ -14,4 +14,12 @@ class Pet < ApplicationRecord
   def self.adoptable
     where(adoptable: true)
   end
+
+  def pet_app_statuses
+    pet_applications.pluck(:pet_status)
+  end
+
+  def self.available_for_adoption
+    select("pets.*").joins(:pet_applications).where.not('pet_applications.pet_status => Approved')
+  end
 end

--- a/app/views/admin/applications/show.html.erb
+++ b/app/views/admin/applications/show.html.erb
@@ -12,9 +12,13 @@
         <%= form.hidden_field :pet_status, value: "Approved" %>
         <%= form.submit "Approve Application for #{pet.name}" %>
       <% end %>
+      <%= form_with url: "/pet_applications/#{pet_app.id}", local: true, method: :patch do |form| %>
+        <%= form.hidden_field :pet_status, value: "Rejected" %>
+        <%= form.submit "Reject Application for #{pet.name}" %>
+      <% end %>
     </div>
-  <% elsif pet_app.pet_status == "Approved" %>
-    <div id="approved-for-<%= pet.id %>">
+  <% elsif pet_app.pet_status == "Approved" || pet_app.pet_status == "Rejected" %>
+    <div id="decision-for-<%= pet.id %>">
       <%= link_to pet.name, "/pets/#{pet.id}" %>
       <p><%= pet_app.pet_status %> for Adoption</p>
     </div>

--- a/spec/features/admin/applications/show_spec.rb
+++ b/spec/features/admin/applications/show_spec.rb
@@ -27,9 +27,30 @@ RSpec.describe "/admin/applications/:id, admin-show page" do
       
       expect(current_path).to eq("/admin/applications/#{application.id}")
 
-      within "#approved-for-#{pet_1.id}" do
+      within "#decision-for-#{pet_1.id}" do
         expect(page).to_not have_button("Approve Application for #{pet_1.name}")
         expect(page).to have_content("Approved for Adoption")
+      end
+    end
+
+    it "Admin can reject a pet application for each pet applied for" do
+
+      visit "/admin/applications/#{application.id}"
+
+      within "#applying-for-#{pet_1.id}" do
+        expect(page).to have_link("#{pet_1.name}")
+        expect(page).to have_button("Approve Application for #{pet_1.name}")
+        expect(page).to have_button("Reject Application for #{pet_1.name}")
+      end
+      
+      find("#applying-for-#{pet_1.id}").click_button("Reject Application for #{pet_1.name}")
+      
+      expect(current_path).to eq("/admin/applications/#{application.id}")
+
+      within "#decision-for-#{pet_1.id}" do
+        expect(page).to_not have_button("Reject Application for #{pet_1.name}")
+        expect(page).to_not have_button("Approve Application for #{pet_1.name}")
+        expect(page).to have_content("Rejected for Adoption")
       end
     end
 end

--- a/spec/models/pet_spec.rb
+++ b/spec/models/pet_spec.rb
@@ -18,6 +18,10 @@ RSpec.describe Pet, type: :model do
     @pet_1 = @shelter_1.pets.create(name: "Mr. Pirate", breed: "tuxedo shorthair", age: 5, adoptable: true)
     @pet_2 = @shelter_1.pets.create(name: "Clawdia", breed: "shorthair", age: 3, adoptable: true)
     @pet_3 = @shelter_1.pets.create(name: "Ann", breed: "ragdoll", age: 3, adoptable: false)
+    @app_1 = Application.create!(name: "Ringo Starr", street_address: "123 Canyon Blvd.", city: "Boulder", state: "CO", zip_code: "80304", description: "I just love pets so much!", status: "Pending")
+    @app_2 = Application.create!(name: "Buddy Boy", street_address: "123 Canyon Blvd.", city: "Boulder", state: "CO", zip_code: "80304", description: "I just hate pets so much!", status: "Pending")
+    @pet_app2 = PetApplication.create!(pet: @pet_1, application: @app_2)
+    @pet_app3 = PetApplication.create!(pet: @pet_2, application: @app_2)
   end
 
   describe "class methods" do
@@ -38,6 +42,12 @@ RSpec.describe Pet, type: :model do
     describe ".shelter_name" do
       it "returns the shelter name for the given pet" do
         expect(@pet_3.shelter_name).to eq(@shelter_1.name)
+      end
+    end
+
+    describe "#available_for_adoption" do
+      it "returns all pets that haven't been already been approved on another application" do
+        pet_app1 = PetApplication.create!(pet: @pet_1, application: @app_1, pet_status: "Approved")
       end
     end
   end


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [X] The commit message follows our guidelines
- [X] The branch created follows our guidelines
- [X] Tests for the changes have been added (for bug fixes/features)



* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Feature that can reject specific pets on a single application.

* **What is the new behavior (if this is a feature change)?**

When an admin visits an admin/application/show page, there are two buttons to either approve or reject all pets on an application.

* **Other information**: